### PR TITLE
Organized using Packages

### DIFF
--- a/entity.py
+++ b/entity.py
@@ -1,8 +1,7 @@
-# Standard imports
 # Third-Party Imports
 import pygame
 # Local Imports
-import globals
+from utilities import globals
 
 # Custom Sprite Class
 class Entity(pygame.sprite.Sprite):

--- a/events/__init__.py
+++ b/events/__init__.py
@@ -1,0 +1,1 @@
+from . import event_handler

--- a/events/event_handler.py
+++ b/events/event_handler.py
@@ -1,8 +1,7 @@
-# Standard Imports
 # Third-Party Imports
 import pygame
 # Local Imports
-import globals
+from utilities import globals
 
 events: list = []
 event_flags: dict = {

--- a/main.py
+++ b/main.py
@@ -3,17 +3,16 @@ import sys
 # Third-Party Imports
 import pygame
 # Local Imports
-import globals
-import textures.texture_manager as texture_manager
-import events.event_handler as event_handler
-# Scenes
-import scenes.scene_manager as scene_manager
+from utilities import globals
+from textures import texture_manager
+from events import event_handler
+from scenes import scene_manager
 
 class Game:
     def __init__(self) -> None:
         pygame.init()
 
-        # Create Screen
+        # Create Screen 
         self.screen: pygame.Surface = pygame.display.set_mode(
             (globals.screen_width, globals.screen_height), # Screen size
             pygame.RESIZABLE, # Screen is resizable
@@ -33,7 +32,7 @@ class Game:
 
         # Initialize game scenes
         scene_manager.init_scenes(self)
-        scene_manager.set_scene('menu')
+        scene_manager.set_scene('world1')
 
     def run(self) -> None:
         while self.running:

--- a/scenes/__init__.py
+++ b/scenes/__init__.py
@@ -1,0 +1,2 @@
+from . import scene_manager
+from .scene_template import SceneTemplate

--- a/scenes/levels/menu.py
+++ b/scenes/levels/menu.py
@@ -1,11 +1,10 @@
-# Standard Imports
 # Third-Party Imports
 import pygame
 # Local Imports
-import globals
-from scenes.scene_template import SceneTemplate
+from utilities import globals
+from ..scene_template import SceneTemplate
 from entity import Entity
-from ui.ui_element import UIElement
+from ui import UIElement
 
 class Menu(SceneTemplate):
     def __init__(self, game) -> None:

--- a/scenes/levels/world1.py
+++ b/scenes/levels/world1.py
@@ -1,11 +1,10 @@
-# Standard Imports
 # Third-Party Imports
 import pygame
 # Local Imports
-import globals
-from scenes.scene_template import SceneTemplate
+from utilities import globals
+from ..scene_template import SceneTemplate
 from entity import Entity
-import events.event_handler as event_handler
+from events import event_handler
 
 class World1(SceneTemplate):
     def __init__(self, game) -> None:

--- a/scenes/scene_manager.py
+++ b/scenes/scene_manager.py
@@ -1,8 +1,6 @@
-# Standard Imports
-# Third-Party Imports
 # Local Imports
-from scenes.levels.menu import Menu
-from scenes.levels.world1 import World1
+from .levels.menu import Menu
+from .levels.world1 import World1
 
 current_scene: str = None
 scenes: dict = None

--- a/scenes/scene_template.py
+++ b/scenes/scene_template.py
@@ -1,10 +1,9 @@
-# Standard Imports
 # Third-Party Imports
 import pygame
 # Local Imports
-import globals
+from utilities import globals
 from entity import Entity
-import textures.texture_manager as texture_manager
+from textures import texture_manager
 
 class SceneTemplate:
     def __init__(self, game) -> None:

--- a/textures/__init__.py
+++ b/textures/__init__.py
@@ -1,0 +1,1 @@
+from . import texture_manager

--- a/textures/texture_manager.py
+++ b/textures/texture_manager.py
@@ -1,9 +1,8 @@
-# Standard Imports
 # Third-Party Imports
 import pygame
 # Local Imports
-import globals
-import textures.texture_data as texture_data
+from utilities import globals
+from . import texture_data
 
 solo_textures: dict = None
 block_textures: dict = None

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,0 +1,1 @@
+from .ui_element import UIElement

--- a/ui/ui_element.py
+++ b/ui/ui_element.py
@@ -1,8 +1,7 @@
-# Standard imports
 # Third-Party Imports
 import pygame
 # Local Imports
-import globals
+from utilities import globals
 from entity import Entity
 
 # Custom Sprite Class

--- a/utilities/__init__.py
+++ b/utilities/__init__.py
@@ -1,0 +1,1 @@
+from . import globals

--- a/utilities/globals.py
+++ b/utilities/globals.py
@@ -1,12 +1,10 @@
 # Standard Imports
 import time
-# Third-Party Imports
-# Local Imports
 
 # Graphics Settings
 screen_width: int = 1280
 screen_height: int = 720
-max_framerate: int = 120
+max_framerate: int = 60
 
 # Framerate independence
 target_framerate: int = 60


### PR DESCRIPTION
All imports were refactored to utilize pythons package system. Each organizational folder was given an "__init__.py" file. Now, all local imports should begin with the name of a package, followed by a module or class name. For example, main.py previously imported the event handler like this: "from events.event_handler import event_handler" This has been simplified as: "from events import event_handler"